### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,9 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - master
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alejandrocuba/alejandrocuba/security/code-scanning/2](https://github.com/alejandrocuba/alejandrocuba/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained by policy in this file rather than inherited defaults.  
Best single fix here (without changing functionality) is to define workflow-level permissions with the minimum baseline (`contents: read`) and the write scope commonly required by Firebase Hosting deploy PR/status interactions (`pull-requests: write`). This keeps checkout working and allows the deploy action’s GitHub interactions, while still reducing broad token access.

Edit file **`.github/workflows/firebase-hosting-merge.yml`** by inserting a root-level `permissions:` block between the trigger (`on`) section and `jobs:`.

No imports, methods, or additional definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
